### PR TITLE
Release GIL for blocking I/O call RetrieveResult() within grab_image()

### DIFF
--- a/cython/factory.pyx
+++ b/cython/factory.pyx
@@ -225,7 +225,10 @@ cdef class Camera:
         assert not image_format.endswith('p'), 'Packed data not supported at this point'
 
         while self.camera.IsGrabbing():
-            self.camera.RetrieveResult(timeout, ptr_grab_result)
+
+            with nogil:
+                # Blocking call into native Pylon C++ SDK code, release GIL so other python threads can run
+                self.camera.RetrieveResult(timeout, ptr_grab_result)
 
             if not ACCESS_CGrabResultPtr_GrabSucceeded(ptr_grab_result):
                 error_desc = (<string>(ACCESS_CGrabResultPtr_GetErrorDescription(ptr_grab_result))).decode()

--- a/cython/pylon_def.pxd
+++ b/cython/pylon_def.pxd
@@ -120,7 +120,8 @@ cdef extern from "pylon/PylonIncludes.h" namespace 'Pylon':
         IPylonDevice* DetachDevice() except +
         void StartGrabbing(size_t maxImages) except +    #FIXME: implement different strategies
         bool IsGrabbing()
-        bool RetrieveResult(unsigned int timeout_ms, CGrabResultPtr& grab_result) except +  # FIXME: Timout handling
+        # RetrieveResult() is blocking call into C++ native SDK, allow it to be called without GIL
+        bool RetrieveResult(unsigned int timeout_ms, CGrabResultPtr& grab_result) nogil except + # FIXME: Timout handling
         INodeMap& GetNodeMap()
 
     cdef cppclass DeviceInfoList_t:


### PR DESCRIPTION
Improves behavior of multi-threaded script retrieving images from multiple cameras simultaneously
